### PR TITLE
Update Docker Compose config & docs to fix path permissions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -145,4 +145,4 @@ setup-installer-site.sh
 install-server.*
 notify-clients-upgrade.sh
 debug-agent.sh
-docker/agents
+docker/compose_dev_data

--- a/docker/README.md
+++ b/docker/README.md
@@ -20,15 +20,22 @@ Version tags are also available (e.g. `1.2.3`) for both of these images.
 ### Production Deployment
 
 1. Download the [Docker Compose file](docker-compose.yml)
-
-2. Configure environment variables (see [Configuration](#configuration) section)
-
-3. Start the application:
+2. Change the default database password in the file:
+   ```yaml
+   environment:
+     POSTGRES_PASSWORD: YOUR_SECURE_PASSWORD_HERE
+   ```
+3. Update the corresponding `DATABASE_URL` in the backend service:
+   ```yaml
+   environment:
+     DATABASE_URL: postgresql://patchmon_user:YOUR_SECURE_PASSWORD_HERE@database:5432/patchmon_db
+   ```
+4. Configure environment variables (see [Configuration](#configuration) section)
+5. Start the application:
    ```bash
    docker compose up -d
    ```
-
-4. Access the application at `http://localhost:3000`
+6. Access the application at `http://localhost:3000`
 
 ## Configuration
 
@@ -61,22 +68,6 @@ Version tags are also available (e.g. `1.2.3`) for both of these images.
 
 - `BACKEND_HOST`: Backend service hostname (default: `backend`)
 - `BACKEND_PORT`: Backend service port (default: 3001)
-
-### Security Configuration
-
-**⚠️ IMPORTANT**: Before deploying to production, you MUST:
-
-1. Change the default database password in `docker-compose.yml`:
-   ```yaml
-   environment:
-     POSTGRES_PASSWORD: YOUR_SECURE_PASSWORD_HERE
-   ```
-
-2. Update the corresponding `DATABASE_URL` in the backend service:
-   ```yaml
-   environment:
-     DATABASE_URL: postgresql://patchmon_user:YOUR_SECURE_PASSWORD_HERE@database:5432/patchmon_db
-   ```
 
 ---
 

--- a/docker/README.md
+++ b/docker/README.md
@@ -69,6 +69,18 @@ Version tags are also available (e.g. `1.2.3`) for both of these images.
 - `BACKEND_HOST`: Backend service hostname (default: `backend`)
 - `BACKEND_PORT`: Backend service port (default: 3001)
 
+### Volumes
+
+The compose file creates two Docker volumes:
+
+* `postgres_data`: PostgreSQL's data directory.
+* `agent_files`: PatchMon's agent files.
+
+If you wish to bind either if their respective container paths to a host path rather than a Docker volume, you can do so in the Docker Compose file.
+
+> [!TIP]
+> The backend container runs as user & group ID 1000. If you plan to re-bind the agent files directory, ensure that the same user and/or group ID has permission to write to the host path to which it's bound.
+
 ---
 
 # Development

--- a/docker/docker-compose.dev.yml
+++ b/docker/docker-compose.dev.yml
@@ -7,7 +7,7 @@ services:
       POSTGRES_USER: patchmon_user
       POSTGRES_PASSWORD: INSECURE_REPLACE_ME_PLEASE_INSECURE
     volumes:
-      - postgres_data:/var/lib/postgresql/data
+      - ./compose_dev_data/db:/var/lib/postgresql/data
     healthcheck:
       test: ["CMD-SHELL", "pg_isready -U patchmon_user -d patchmon_db"]
       interval: 10s
@@ -31,7 +31,7 @@ services:
       RATE_LIMIT_WINDOW_MS: 900000
       RATE_LIMIT_MAX: 100
     volumes:
-      - ./agents:/app/agents
+      - ./compose_dev_data/agents:/app/agents
     depends_on:
       database:
         condition: service_healthy
@@ -49,6 +49,3 @@ services:
     depends_on:
       backend:
         condition: service_healthy
-
-volumes:
-  postgres_data:

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -29,7 +29,7 @@ services:
       RATE_LIMIT_WINDOW_MS: 900000
       RATE_LIMIT_MAX: 100
     volumes:
-      - ./agents:/app/agents
+      - agent_files:/app/agents
     depends_on:
       database:
         condition: service_healthy
@@ -45,3 +45,4 @@ services:
 
 volumes:
   postgres_data:
+  agent_files:


### PR DESCRIPTION
Works around path permissions issues people have been having by moving them to a Docker volume, eliminating the issue entirely, and also adding a docs note on permissions, should users wish to bind the directory to a host path.